### PR TITLE
Patch to add a watch & dispose API

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,17 +44,19 @@ At any time you can rewatch or stop watching, by using the `watch` and ` dispose
 ```js
 var inViewport = require('in-viewport');
 var elem = document.getElementById('myFancyDiv');
-var count = 0; 
+var count = 0;
+var timer;
 
 var watcher = inViewport(elem, visible);
 
 function visible() {
   count++;
-  setTimeout(watcher.watch, 1000); 
+  timer = setTimeout(watcher.watch, 1000); 
 }
 
 setTimeout(function(){
   watcher.dispose();
+  clearTimeout(timer);
   alert('myfancyDiv was visible '+count+' seconds in the last 10 seconds!');
 }, 10000); 
 ```

--- a/README.md
+++ b/README.md
@@ -31,10 +31,33 @@ inViewport(elem, visible);
 
 function visible(elt) {
   // elt === elem
-  alert(elt.id + ' is visible in the window !');
+  alert(elt.id + ' is visible in the window!');
 }
 ```
 The first callback argument is always the `element` that entered the viewport.
+
+### callback watcher API
+
+The callback is called only one time, when the `element` is in the viewport for the first time.
+At any time you can rewatch or stop watching, by using the `watch` and ` dispose` API. 
+
+```js
+var inViewport = require('in-viewport');
+var elem = document.getElementById('myFancyDiv');
+var count = 0; 
+
+var watcher = inViewport(elem, visible);
+
+function visible() {
+  count++;
+  setTimeout(watcher.watch, 1000); 
+}
+
+setTimeout(function(){
+  watcher.dispose();
+  alert('myfancyDiv was visible '+count+' seconds in the last 10 seconds!');
+}, 10000); 
+```
 
 ### A custom container
 
@@ -49,7 +72,7 @@ var elem = document.getElementById('myFancyDiv');
 inViewport(elem, { container: customContainer }, visible);
 
 function visible() {
-  alert('myfancyDiv is visible in the `customContainer` !');
+  alert('myfancyDiv is visible in the `customContainer`!');
 }
 ```
 
@@ -69,7 +92,7 @@ var elem = document.getElementById('myFancyDiv');
 inViewport(elem, { offset: 300 }, visible);
 
 function visible() {
-  alert('myfancyDiv is visible in the `customContainer` !');
+  alert('myfancyDiv is visible in the `customContainer`!');
 }
 ```
 

--- a/example/simple.html
+++ b/example/simple.html
@@ -23,7 +23,7 @@
   <script>
   var el = document.getElementById('test');
 
-  inViewport(el, function() {
+  var watcher = inViewport(el, function() {
     alert('YES');
   });
   </script>

--- a/in-viewport.js
+++ b/in-viewport.js
@@ -97,12 +97,12 @@ function createInViewport(container) {
       return isVisible(elt, offset);
     }
 
-    var accessor = createAccessor(elt, offset, cb);
-    accessor.watch();
-    return accessor;
+    var remote = createRemote(elt, offset, cb);
+    remote.watch();
+    return remote;
   }
 
-  function createAccessor(elt, offset, cb) {
+  function createRemote(elt, offset, cb) {
     function watch() {
       watches.add(elt, offset, cb);
     }

--- a/in-viewport.js
+++ b/in-viewport.js
@@ -194,7 +194,7 @@ function createWatches() {
   var watches = [];
 
   function add(elt, offset, cb) {
-    setTimeout(function() {
+    setTimeout(function () {
       if (!contains(elt)) {
         watches.push([elt, offset, cb])
       }

--- a/test/dispose.js
+++ b/test/dispose.js
@@ -1,0 +1,42 @@
+describe('asking if a visible div scrolled', function() {
+  require('./fixtures/bootstrap.js');
+  beforeEach(h.clean);
+  afterEach(h.clean);
+
+  var visible = false;
+  var element;
+  var watcher;
+
+  beforeEach(function(done) {
+    element = h.createTest({
+      style: {
+        top: '10000px'
+      }
+    });
+    h.insertTest(element);
+    watcher = inViewport(element, function() {
+      scrolled = true;
+      done();
+    });
+  });
+  
+  describe('when the watcher is not active', function() {
+    beforeEach(watcher.dispose());
+    beforeEach(h.scroller(0, 10000));
+    beforeEach(h.scroller(0, 0));
+
+    it('cb not called', function() {
+      assert.strictEqual(calls.length, 0);
+    });
+  });
+
+  describe('when the watcher is active', function() {
+    beforeEach(watcher.watch());
+    beforeEach(h.scroller(0, 10000));
+    beforeEach(h.scroller(0, 0));
+
+    it('cb called', function() {
+      assert.strictEqual(calls.length, 1);
+    });
+  });
+});

--- a/test/dispose.js
+++ b/test/dispose.js
@@ -1,4 +1,4 @@
-describe('asking if a visible div scrolled', function() {
+describe('using the watcher API to dispose and watch again', function() {
   require('./fixtures/bootstrap.js');
   beforeEach(h.clean);
   afterEach(h.clean);


### PR DESCRIPTION
Hi @vvo!

Since I've seen the open issue and I like this project, I would like to try to provide a watch / dispose API.

I had to make some code reorganization, so you probably won't like it :(
I made 3 commits, you should probably review one by one, it would be easier:

1. Add a test for the dispose API
2. Regroup `watches` & `watching` variables and add an API over it to make the code more readable & maintainable. This was not mandatory, but it simplify a lot the next reorganization.
3. Add a `watch` & `dispose` API when isInViewport is called with a callback.

There is no hurry with this PR.
I'm available to help if you're interested in this feature.

Cheers,
Thomas.