### PR TITLE
Fix: Allow to use an offset with a custom container

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 (The MIT Licence)
 
-Copyright (c) Vincent Voyer
+Copyright (c) 2013-2016 Vincent Voyer
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ function visible(elt) {
 ```
 The first callback argument is always the `element` that entered the viewport.
 
-### callback watcher API
+### Callback watcher API
 
 The callback is called only one time, when the `element` is in the viewport for the first time.
 At any time you can rewatch or stop watching, by using the `watch` and ` dispose` API. 
@@ -158,7 +158,7 @@ Please consider using [browserify](https://github.com/substack/node-browserify).
 
 ## License
 
-Copyright (c) 2013 Vincent Voyer
+Copyright (c) 2013-2016 Vincent Voyer
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/example/container-offset.html
+++ b/example/container-offset.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Example with a custom container and an offset</title>
+
+  <style>
+    #container {
+      height: 150px;
+      margin: 50px;
+      border: 1px solid #000;
+      overflow: auto;
+    }
+    #wrapper {
+      padding: 0 2000px;
+    }
+    #test {
+      position: relative;
+      width: 100px;
+      height: 100px;
+      background: #000;
+    }
+    #test::before {
+      content: '';
+      position: absolute;
+      top: -500px;
+      left: -500px;
+      right: -500px;
+      bottom: -500px;
+      z-index: -1;
+      border: 1px dashed #666;
+      background: #F5F5F5;
+    }
+  </style>
+</head>
+<body>
+  <h1>Custom container example with an offset</h1>
+
+  <div id="container">
+    <div id="wrapper">
+      <div id="test"></div>
+    </div>
+  </div>
+
+  <script src="../build/in-viewport.min.js"></script>
+  <script>
+  var container = document.getElementById('container');
+  var el = document.getElementById('test');
+
+  var watcher = inViewport(el, {container: container, offset: 500}, function() {
+    alert('in custom viewport, in 500px');
+  });
+  </script>
+</body>
+</html>

--- a/example/container.html
+++ b/example/container.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Example with a custom container</title>
+
+  <style>
+    #container {
+      height: 150px;
+      margin: 50px;
+      border: 1px solid #000;
+      overflow: auto;
+    }
+    #wrapper {
+      padding: 0 2000px;
+    }
+    #test {
+      position: relative;
+      width: 100px;
+      height: 100px;
+      background: #000;
+    }
+  </style>
+</head>
+<body>
+  <h1>Custom container example</h1>
+
+  <div id="container">
+    <div id="wrapper">
+      <div id="test"></div>
+    </div>
+  </div>
+
+  <script src="../build/in-viewport.min.js"></script>
+  <script>
+  var container = document.getElementById('container');
+  var el = document.getElementById('test');
+
+  var watcher = inViewport(el, {container: container}, function() {
+    alert('in custom viewport');
+  });
+  </script>
+</body>
+</html>

--- a/example/invisible-element.html
+++ b/example/invisible-element.html
@@ -13,19 +13,18 @@
   </style>
 </head>
 <body>
-  <div class="context">Coucou</div>
+  <h1 class="context">Invisible element example</h1>
 
   <div class="hidden">
     <div class="test"></div>
   </div>
 
   <script src="../build/in-viewport.min.js"></script>
-
   <script>
   var el = document.querySelector('.test');
 
   inViewport(el, function() {
-    alert('YES');
+    alert('in viewport');
   });
   </script>
 </body>

--- a/example/offset.html
+++ b/example/offset.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Example with offset</title>
+
+  <style>
+    #test {
+      position: relative;
+      top: 2000px;
+      width: 10px;
+      height: 10px;
+      background: #000;
+    }
+    #test:before {
+      content: '';
+      position: absolute;
+      top: -500px;
+      left: -500px;
+      right: -500px;
+      bottom: -500px;
+      z-index: -1;
+      border: 1px dashed #666;
+      background: #F5F5F5;
+    }
+  </style>
+</head>
+<body>
+  <h1>Offset example</h1>
+
+  <div id="test"></div>
+
+  <script src="../build/in-viewport.min.js"></script>
+  <script>
+  var el = document.getElementById('test');
+
+  var watcher = inViewport(el, {offset: 500}, function() {
+    alert('in viewport, in 500px');
+  });
+  </script>
+</body>
+</html>

--- a/example/simple.html
+++ b/example/simple.html
@@ -5,7 +5,7 @@
 
   <style>
     #test {
-      position:relative;
+      position: relative;
       top: 2000px;
       width: 10px;
       height: 10px;
@@ -14,17 +14,16 @@
   </style>
 </head>
 <body>
+  <h1>Simple example</h1>
 
   <div id="test"></div>
-  <div>Coucou</div>
 
   <script src="../build/in-viewport.min.js"></script>
-
   <script>
   var el = document.getElementById('test');
 
   var watcher = inViewport(el, function() {
-    alert('YES');
+    alert('in viewport');
   });
   </script>
 </body>

--- a/in-viewport.js
+++ b/in-viewport.js
@@ -136,49 +136,32 @@ function createInViewport(container) {
     }
 
     var eltRect = elt.getBoundingClientRect();
-    var containerRect = container.getBoundingClientRect();
-
-    var pos = {
-      left: eltRect.left,
-      top: eltRect.top
-    };
-
-    var viewport = {
-      width: offset,
-      height: offset
-    };
+    var viewport = {};
 
     if (container === global.document.body) {
-      viewport.width += global.document.documentElement.clientWidth;
-      viewport.height += global.document.documentElement.clientHeight;
-
-      // We update body rect computing because
-      // when you have relative/absolute childs, you get bad compute
-      // we need to create a new Object, because it's read only
-      containerRect = {
-        bottom: container.scrollHeight,
-        top: 0,
-        left: 0,
-        right: container.scrollWidth
+      viewport = {
+        top: -offset,
+        left: -offset,
+        right: global.document.documentElement.clientWidth + offset,
+        bottom: global.document.documentElement.clientHeight + offset
       };
     } else {
-      pos.left -= containerRect.left;
-      pos.top -= containerRect.top;
-      viewport.width += container.clientWidth;
-      viewport.height += container.clientHeight;
+      var containerRect = container.getBoundingClientRect();
+      viewport = {
+        top: containerRect.top - offset,
+        left: containerRect.left - offset,
+        right: containerRect.right + offset,
+        bottom: containerRect.bottom + offset
+      };
     }
 
+    // The element must overlap with the visible part of the viewport
     var visible =
-      // 1. They must overlap
-      !(
-        eltRect.right < containerRect.left ||
-        eltRect.left > containerRect.right ||
-        eltRect.bottom < containerRect.top ||
-        eltRect.top > containerRect.bottom
-      ) && (
-        // 2. They must be visible in the viewport
-        pos.top <= viewport.height &&
-        pos.left <= viewport.width
+      (
+        eltRect.right >= viewport.left &&
+        eltRect.left <= viewport.right &&
+        eltRect.bottom >= viewport.top &&
+        eltRect.top <= viewport.bottom
       );
 
     return visible;

--- a/test/custom-container-with-offset.js
+++ b/test/custom-container-with-offset.js
@@ -1,0 +1,97 @@
+describe('using offsets with a div as a reference container', function() {
+  require('./fixtures/bootstrap.js');
+  beforeEach(h.clean);
+  afterEach(h.clean);
+
+  var test;
+  var container;
+  var calls;
+  var width = 500;
+  var position = 1000;
+  var offset = 200;
+
+  beforeEach(function() {
+    calls = [];
+    test = h.createTest({
+      style: {
+        left: position + 'px',
+        top: position + 'px'
+      }
+    });
+
+    container = h.createTest({
+      attributes: {
+        id: 'container'
+      },
+      style: {
+        width: width + 'px',
+        height: width + 'px',
+        overflow: 'scroll'
+      }
+    });
+
+    container.innerHTML = '<div class="scrollTrigger"></div>';
+
+    h.insertTest(test, container);
+    h.insertTest(container);
+
+    inViewport(test, {
+      container: container,
+      offset: offset
+    }, cb);
+  });
+
+  describe('when we scroll down on body', function() {
+    beforeEach(h.scroller(position, position));
+
+    it('cb not called', function() {
+      assert.strictEqual(calls.length, 0);
+    });
+  });
+
+  describe('when we scroll inside the container', function() {
+
+    describe('before the element', function () {
+      var scrollBefore = position - width - offset - 2;
+      beforeEach(h.scroller(100, 100, 'container'));
+      beforeEach(h.scroller(scrollBefore, scrollBefore, 'container'));
+
+      it('cb not called', function() {
+        assert.strictEqual(calls.length, 0);
+      });
+    });
+
+    describe('too far after the element', function() {
+      var scrollFarAfter = 2 * position;
+      beforeEach(h.scroller(scrollFarAfter, scrollFarAfter, 'container'));
+
+      it('cb not called', function() {
+        assert.strictEqual(calls.length, 0);
+      });
+    });
+
+    describe('to the element', function() {
+      var scrollToTheElement = position - width;
+      beforeEach(h.scroller(scrollToTheElement, scrollToTheElement, 'container'));
+      beforeEach(h.wait(50));
+
+      it('cb was called', function() {
+        assert.strictEqual(calls.length, 1);
+      });
+    });
+
+    describe('in the offset range', function() {
+      var scrollInTheOffset = position - width - offset;
+      beforeEach(h.scroller(scrollInTheOffset, scrollInTheOffset, 'container'));
+      beforeEach(h.wait(50));
+
+      it('cb was called', function() {
+        assert.strictEqual(calls.length, 1);
+      });
+    });
+  });
+
+  function cb(result) {
+    calls.push(result);
+  }
+});

--- a/test/detached.js
+++ b/test/detached.js
@@ -27,7 +27,7 @@ describe('detached DOM node', function() {
       if (typeof MutationObserver === 'function') {
         describe('when the browser supports `MutationObserver`', function () {
 
-          beforeEach(h.wait(50));
+          beforeEach(h.wait(200));
 
           it('cb called', function() {
             assert.strictEqual(visible, true);


### PR DESCRIPTION
Hi @vvo!

We have to deal with custom containers for the lazyload of the Mapado projects.
It appears this library doesn't handle the offset parameter with custom containers.

What is in this PR:

 * Two examples for a custom container and an offset when used separately
 * An example for a custom container with an offset, to reproduce the failing use case.
 * The associated failing test
 * A fix for the test & the example
 * An update of the copyright year
 
On my way to find a fix, I simplified the conditions to test if an element is visible.
Instead of testing if the element overlaps the viewport **and** is in the visible part, I directly test if the element overlaps the visible part of the viewport.
It seems simpler to understand, at least for me :dancer:, and simpler to maintain.
I also think it makes less calculations, because I removed a  `getBoundingClientRect()` that wasn't used when there is no custom container.

Thanks again for maintaining this project!
I stay available for any need of help or explanations ;)

Cheers,
Thomas.