### PR TITLE
Feature request: Check the global viewport even if a custom container is given

### DIFF
--- a/example/custom-container-off-viewport.html
+++ b/example/custom-container-off-viewport.html
@@ -1,17 +1,18 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>Example with a custom container</title>
+  <title>Off-viewport custom container example</title>
 
   <style>
     #container {
       height: 150px;
-      margin: 50px;
+      margin: 2000px 50px 50px;
       border: 1px solid #000;
-      overflow: auto;
+      overflow-x: auto;
+      overflow-y: hidden;
     }
     #wrapper {
-      padding: 0 2000px;
+      padding: 0 2000px 0 0;
     }
     #test {
       position: relative;
@@ -22,7 +23,7 @@
   </style>
 </head>
 <body>
-  <h1>Custom container example</h1>
+  <h1>Off-viewport custom container example</h1>
 
   <div id="container">
     <div id="wrapper">

--- a/example/custom-container-offset.html
+++ b/example/custom-container-offset.html
@@ -1,14 +1,15 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>Example with a custom container and an offset</title>
+  <title>Custom container example with an offset</title>
 
   <style>
     #container {
       height: 150px;
       margin: 50px;
       border: 1px solid #000;
-      overflow: auto;
+      overflow-x: auto;
+      overflow-y: hidden;
     }
     #wrapper {
       padding: 0 2000px;

--- a/example/custom-container.html
+++ b/example/custom-container.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Custom container example</title>
+
+  <style>
+    #container {
+      height: 150px;
+      margin: 50px;
+      border: 1px solid #000;
+      overflow-x: auto;
+      overflow-y: hidden;
+    }
+    #wrapper {
+      padding: 0 2000px;
+    }
+    #test {
+      position: relative;
+      width: 100px;
+      height: 100px;
+      background: #000;
+    }
+  </style>
+</head>
+<body>
+  <h1>Custom container example</h1>
+
+  <div id="container">
+    <div id="wrapper">
+      <div id="test"></div>
+    </div>
+  </div>
+
+  <script src="../build/in-viewport.min.js"></script>
+  <script>
+  var container = document.getElementById('container');
+  var el = document.getElementById('test');
+
+  var watcher = inViewport(el, {container: container}, function() {
+    alert('in custom viewport');
+  });
+  </script>
+</body>
+</html>

--- a/example/offset.html
+++ b/example/offset.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>Example with offset</title>
+  <title>Offset example</title>
 
   <style>
     #test {

--- a/test/custom-container-with-offset.js
+++ b/test/custom-container-with-offset.js
@@ -6,9 +6,10 @@ describe('using offsets with a div as a reference container', function() {
   var test;
   var container;
   var calls;
-  var width = 500;
+  var size = 300;
   var position = 1000;
   var offset = 200;
+  var containerTop = 3000;
 
   beforeEach(function() {
     calls = [];
@@ -24,8 +25,9 @@ describe('using offsets with a div as a reference container', function() {
         id: 'container'
       },
       style: {
-        width: width + 'px',
-        height: width + 'px',
+        top: containerTop + 'px',
+        width: size + 'px',
+        height: size + 'px',
         overflow: 'scroll'
       }
     });
@@ -41,52 +43,64 @@ describe('using offsets with a div as a reference container', function() {
     }, cb);
   });
 
-  describe('when we scroll down on body', function() {
-    beforeEach(h.scroller(position, position));
+  describe('when we do not scroll down on body', function() {
 
-    it('cb not called', function() {
-      assert.strictEqual(calls.length, 0);
+    describe('when we scroll inside the container', function() {
+
+      describe('to the element', function () {
+        var scrollToTheElement = position - size;
+        beforeEach(h.scroller(scrollToTheElement, scrollToTheElement, 'container'));
+        beforeEach(h.wait(50));
+
+        it('cb not called', function () {
+          assert.strictEqual(calls.length, 0);
+        });
+      });
     });
   });
 
-  describe('when we scroll inside the container', function() {
+  describe('when we scroll down on body', function() {
+    beforeEach(h.scroller(0, containerTop));
 
-    describe('before the element', function () {
-      var scrollBefore = position - width - offset - 2;
-      beforeEach(h.scroller(100, 100, 'container'));
-      beforeEach(h.scroller(scrollBefore, scrollBefore, 'container'));
+    describe('when we scroll inside the container', function() {
 
-      it('cb not called', function() {
-        assert.strictEqual(calls.length, 0);
+      describe('to the element', function() {
+        var scrollToTheElement = position - size;
+        beforeEach(h.scroller(scrollToTheElement, scrollToTheElement, 'container'));
+        beforeEach(h.wait(50));
+
+        it('cb was called', function() {
+          assert.strictEqual(calls.length, 1);
+        });
       });
-    });
 
-    describe('too far after the element', function() {
-      var scrollFarAfter = 2 * position;
-      beforeEach(h.scroller(scrollFarAfter, scrollFarAfter, 'container'));
+      describe('before the element', function () {
+        var scrollBefore = position - size - offset - 2;
+        beforeEach(h.scroller(100, 100, 'container'));
+        beforeEach(h.scroller(scrollBefore, scrollBefore, 'container'));
 
-      it('cb not called', function() {
-        assert.strictEqual(calls.length, 0);
+        it('cb not called', function() {
+          assert.strictEqual(calls.length, 0);
+        });
       });
-    });
 
-    describe('to the element', function() {
-      var scrollToTheElement = position - width;
-      beforeEach(h.scroller(scrollToTheElement, scrollToTheElement, 'container'));
-      beforeEach(h.wait(50));
+      describe('in the offset range', function() {
+        var scrollInTheOffset = position - size - offset;
+        beforeEach(h.scroller(scrollInTheOffset, scrollInTheOffset, 'container'));
+        beforeEach(h.wait(50));
 
-      it('cb was called', function() {
-        assert.strictEqual(calls.length, 1);
+        it('cb was called', function() {
+          assert.strictEqual(calls.length, 1);
+        });
       });
-    });
 
-    describe('in the offset range', function() {
-      var scrollInTheOffset = position - width - offset;
-      beforeEach(h.scroller(scrollInTheOffset, scrollInTheOffset, 'container'));
-      beforeEach(h.wait(50));
+      describe('too far after the element', function() {
+        var scrollFarAfter = 2 * position;
+        beforeEach(h.scroller(scrollFarAfter, scrollFarAfter, 'container'));
 
-      it('cb was called', function() {
-        assert.strictEqual(calls.length, 1);
+        it('cb not called', function() {
+          assert.strictEqual(calls.length, 0);
+        });
       });
     });
   });

--- a/test/custom-container.js
+++ b/test/custom-container.js
@@ -6,13 +6,16 @@ describe('using a div as a reference container', function() {
   var test;
   var container;
   var calls;
+  var size = 300;
+  var position = 1000;
+  var containerTop = 3000;
 
   beforeEach(function() {
     calls = [];
     test = h.createTest({
       style: {
-        left: '1000px',
-        top: '1000px'
+        left: position + 'px',
+        top: position + 'px'
       }
     });
 
@@ -21,8 +24,9 @@ describe('using a div as a reference container', function() {
         id: 'container'
       },
       style: {
-        width: '500px',
-        height: '500px',
+        top: containerTop + 'px',
+        width: size + 'px',
+        height: size + 'px',
         overflow: 'scroll'
       }
     });
@@ -37,53 +41,59 @@ describe('using a div as a reference container', function() {
     }, cb);
   });
 
-  describe('when we scroll down on body', function() {
-    beforeEach(h.scroller(1000, 1000));
+  describe('when we do not scroll down on body', function() {
 
-    it('cb not called', function() {
-      assert.strictEqual(calls.length, 0);
+    describe('when we scroll inside the container to the element', function () {
+      beforeEach(h.scroller(position, position, 'container'));
+      beforeEach(h.wait(50));
+
+      it('cb not called', function() {
+        assert.strictEqual(calls.length, 0);
+      });
     });
   });
 
-  describe('when we scroll inside the container', function() {
+  describe('when we scroll down on body', function() {
+    beforeEach(h.scroller(0, containerTop));
 
-    describe('before the div', function () {
-      beforeEach(h.scroller(100, 100, 'container'));
+    describe('when we scroll inside the container', function() {
 
-      it('cb not called', function() {
-        assert.strictEqual(calls.length, 0);
+      describe('to the element', function() {
+        beforeEach(h.scroller(position, position, 'container'));
+        beforeEach(h.wait(50));
+
+        it('cb was called', function() {
+          assert.strictEqual(calls.length, 1);
+        });
+      });
+
+      describe('before the div', function () {
+        beforeEach(h.scroller(100, 100, 'container'));
+
+        it('cb not called', function() {
+          assert.strictEqual(calls.length, 0);
+        });
+      });
+
+      describe('too far after the div', function() {
+        beforeEach(h.scroller(2*position, 2*position, 'container'));
+
+        it('cb not called', function() {
+          assert.strictEqual(calls.length, 0);
+        });
+      });
+
+      describe('when we scroll down, up, like crazy', function() {
+        beforeEach(h.scroller(0, 200, 'container'));
+        beforeEach(h.scroller(0, position, 'container'));
+        beforeEach(h.scroller(0, 20000, 'container'));
+        beforeEach(h.scroller(position, position, 'container'));
+
+        it('cb was called once', function() {
+          assert.strictEqual(calls.length, 1);
+        });
       });
     });
-
-    describe('too far after the div', function() {
-      beforeEach(h.scroller(10000, 10000, 'container'));
-
-      it('cb not called', function() {
-        assert.strictEqual(calls.length, 0);
-      });
-    });
-
-    describe('to the element', function() {
-      beforeEach(h.scroller(1000, 1000, 'container'));
-      beforeEach(h.scroller(1005, 1005, 'container'));
-      beforeEach(h.wait(50));
-
-      it('cb was called', function() {
-        assert.strictEqual(calls.length, 1);
-      });
-    });
-
-    describe('when we scroll down, up, like crazy', function() {
-      beforeEach(h.scroller(0, 200, 'container'));
-      beforeEach(h.scroller(0, 1000, 'container'));
-      beforeEach(h.scroller(0, 20000, 'container'));
-      beforeEach(h.scroller(1000, 1000, 'container'));
-
-      it('cb was called once', function() {
-        assert.strictEqual(calls.length, 1);
-      });
-    });
-
   });
 
   function cb(result) {


### PR DESCRIPTION
Hi @vvo!

*This PR is a continuation of the #13, but I think it's more a feature request than a fix.*

We use a pattern that we call "buckets", it is an horizontal slider than contains some content.
Some pages are a long vertical stack of "buckets".
When we added lazyloading on these horizontal sliders, we declared them as custom container. 

Our problem: **a custom container that are not in the global viewport, loads some images anyway**.
Because the images are marked as visible if they are in visible part of the buckets, even if the bucket itself are not visible.

There could already be a solution to handle our use case, but we didn't found it.
So to start this discussion, we propose **a** solution, to check the global viewport even if a custom container is given.

Thanks for maintaining this project!

Cheers,
Thomas.

 