### PR TITLE
If element height is 0, return it instead of `false`

### DIFF
--- a/in-viewport.js
+++ b/in-viewport.js
@@ -148,12 +148,6 @@ function createInViewport(container, debounceValue, failsafe) {
       return false;
     }
 
-    // Check if the element is visible
-    // https://github.com/jquery/jquery/blob/740e190223d19a114d5373758127285d14d6b71e/src/css/hiddenVisibleSelectors.js
-    if (!elt.offsetWidth || !elt.offsetHeight) {
-      return false;
-    }
-
     var eltRect = elt.getBoundingClientRect();
     var viewport = {};
 


### PR DESCRIPTION
Change proposed by @TehShrike on #16.

This changes the behavior on cases where the **height** of the element is `0`.

Instead of returning `false`, it will return `0` instead.

This happens because the element is on screen but, as it has a height of 0, it is not displayed.
The result is a`falsy` one as before, but now people can check if it is indeed on screen by checking by type (`boolean` or `number`)